### PR TITLE
오류 수정 및 해더 파싱 함수, Config 객체 연결 로직 추가

### DIFF
--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -36,6 +36,7 @@ class Client
 
 		void recvStartLine(const std::string &);
 		void recvHeader(const std::string &);
+		void setConfig(ConfigGroup &group);
 		void recvBody();
 		void procCgi();
 		void makeMsg();

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -34,8 +34,8 @@ class Client
 	public:
 		Client(Socket &socket);
 
-		void recvStartLine(const std::string &);
-		void recvHeader(const std::string &);
+		void parseStartLine(const std::string &);
+		void parseHeader(const std::string &);
 		void setConfig(ConfigGroup &group);
 		void recvBody();
 		void procCgi();

--- a/includes/ConfigGroup.hpp
+++ b/includes/ConfigGroup.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Config.hpp"
+#include "utils.hpp"
 
 #include <vector>
 #include <string>
@@ -35,5 +36,3 @@ class ConfigGroup
 			virtual const char *what() const throw();
 		};
 };
-
-bool isBlankLine(const std::string &line);

--- a/includes/Http.hpp
+++ b/includes/Http.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Method.hpp"
+#include "ConfigGroup.hpp"
 
 #include <map>
 #include <deque>
@@ -29,6 +30,7 @@ class Http
 
 	public:
 		void insertToHeader(const std::string &, const std::string &);
+		std::string getHeaderValue(const std::string &);
 };
 
 class HttpRequest : public Http

--- a/includes/utils.hpp
+++ b/includes/utils.hpp
@@ -9,6 +9,9 @@
 #include <netinet/in.h>
 
 std::vector<std::string> ft_split(std::string str, char delim);
+bool isBlankLine(const std::string &line);
+void ft_trim(std::string &str, const std::string cut);
+
 
 #ifndef FT_FD_SETSIZE
 #define FT_FD_SETSIZE 256

--- a/srcs/ConfigGroup.cpp
+++ b/srcs/ConfigGroup.cpp
@@ -189,19 +189,3 @@ const char *ConfigGroup::ConfigFormatException::what() const throw()
 {
     return ("ConfigFormatException: Invalid format!");
 }
-
-/**
- * isBlankLine
- * 가져온 문자열에 공백이나 탭으로만 이루어져있는지 확인하는 함수
- * @param  {std::string} line : 확인할 문자열
- * @return {bool}             : 공백이나 탭으로만 이루어져있으면 참
- */
-bool isBlankLine(const std::string &line)
-{
-    for (size_t i = 0; i < line.size(); i++)
-    {
-        if (line[i] != ' ' && line[i] != '\t')
-            return false;
-    }
-    return true;
-}

--- a/srcs/ConfigGroup.cpp
+++ b/srcs/ConfigGroup.cpp
@@ -122,17 +122,17 @@ ConfigGroup::~ConfigGroup() {}
 
 int ConfigGroup::getServerCnt()
 {
-    return (_configs.size());
+    return (this->_configs.size());
 }
 
 uint32_t ConfigGroup::getMaxConnection()
 {
-    return (_max_connection);
+    return (this->_max_connection);
 }
 
 std::vector<Config> &ConfigGroup::getConfig(int index)
 {
-    return (_configs[index]);
+    return (this->_configs[index]);
 }
 
 /* -------------------------- */

--- a/srcs/Http.cpp
+++ b/srcs/Http.cpp
@@ -1,4 +1,4 @@
-#include "webserv.hpp"
+#include "Http.hpp"
 
 /**
  * std::pair(key, value)를 만들어 http 헤더(multimap)에 insert해주는 함수.
@@ -8,7 +8,21 @@
  */
 void Http::insertToHeader(const std::string &key, const std::string &value)
 {
-	_headers.insert(std::make_pair(key, value));
+	this->_headers.insert(std::make_pair(key, value));
+}
+
+/**
+ * Http::getHeaderValue
+ * 매개변수로 넣은 키값을 바탕으로 value를 반환해주는 함수
+ * @param  {const std::string} key : 찾을 헤더의 key값
+ * @return {std::string}           : 헤더가 있으면 value값, 없으면 빈 문자열 ("")
+ */
+std::string Http::getHeaderValue(const std::string &key)
+{
+	std::multimap<std::string, std::string>::iterator result = this->_headers.find(key);
+	if (result == this->_headers.end())
+		return "";
+	return (*result).second;
 }
 
 /**

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -10,7 +10,7 @@ Server::Server(std::vector<Config> &config):
 	_server_name(config[0].server_name),
 	_port(config[0].port)
 {
-	(void)_config;
+	
 }
 
 uint16_t Server::getPort()

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -10,10 +10,17 @@
 std::vector<std::string> ft_split(std::string str, char delim)
 {
 	std::vector<std::string> answer;
-    std::stringstream ss(str);
-    std::string temp;
-
-    while (std::getline(ss, temp, delim))
-        answer.push_back(temp);
+    int curr = 0, prev = 0;
+    answer.clear();
+   
+    curr = str.find(delim);
+    while (curr != std::string::npos)
+    {
+        answer.push_back(str.substr(prev, curr - prev));
+        prev = curr + 1;
+        curr = str.find(delim, prev);
+    }
+    answer.push_back(str.substr(prev, curr - prev));
+    
     return answer;
 }

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -24,3 +24,41 @@ std::vector<std::string> ft_split(std::string str, char delim)
     
     return answer;
 }
+
+/**
+ * isBlankLine
+ * 가져온 문자열에 공백이나 탭으로만 이루어져있는지 확인하는 함수
+ * @param  {std::string} line : 확인할 문자열
+ * @return {bool}             : 공백이나 탭으로만 이루어져있으면 참
+ */
+bool isBlankLine(const std::string &line)
+{
+	for (size_t i = 0; i < line.size(); i++)
+	{
+        if (line[i] != ' ' && line[i] != '\t')
+            return false;
+    }
+    return true;
+}
+
+/**
+ * ft_trim
+ * @brief  문자열의 앞뒤에서 해당하는 문자들을 자른다.
+ * @param  {std::string} str : 대상 문자열
+ * @param  {std::string} cut : 자를 문자 모음
+ */
+void ft_trim(std::string &str, const std::string cut)
+{
+	std::size_t found = str.find_last_not_of(cut);
+	if (found != std::string::npos)
+		str.erase(found + 1);
+	else
+		str.clear();
+
+	found = str.find_first_not_of(cut);
+	if (found != std::string::npos)
+		str.erase(0, found);
+	else
+		str.clear();
+}
+


### PR DESCRIPTION
#4 이슈 관련 로직을 추가하고, 추가로 함수 하나를 구현했습니다.

void Client::setConfig(ConfigGroup &group)
recvHeader 상태가 끝나고 recvBody 상태가 되면 들어온 request를 처리하기 위해 Config 파일을 Client에 연결해야됩니다.
이를 작동하게 하는 함수를 구현했습니다.
아직 어디에 이 함수를 넣어야할지 고민인데, 제 생각은 write 할 차례가 올때 써야 되지 않을까 생각합니다.

추가로 이전에 말했던 ft_split 관련 오류도 수정해 올렸습니다!

closed #4 