### PR TITLE
body_length에 따른 status  변경 및 head_length 삭제

### DIFF
--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -48,7 +48,8 @@ class Client
 		int				_fd;
 		uint16_t		_port;
 		int				_content_length_left;
-		int				_chunked_len;
+		int				_body_length_left;
+		int				_chunked_length;
 		std::string		_buffer;
 		e_sock_status	_sock_status;
 		e_proc_status	_proc_status;
@@ -66,6 +67,7 @@ class Client
 		std::string autoindex();
 		void makePutMsg();
 		void makePostMsg();
+
 
 		void procCgi();
 
@@ -85,9 +87,12 @@ class Client
 		void makeBasicHeader();
 		void makeErrorStatus(uint16_t status);
 
+		void setBodyLength();
+
 		int				getFd();
 		e_sock_status	getSockStatus();
 		e_proc_status	getProcStatus();
+		void			setProcStatus(e_proc_status status);
 
 		class SocketAcceptException: public std::exception
 		{

--- a/includes/Config.hpp
+++ b/includes/Config.hpp
@@ -14,7 +14,6 @@ struct Config
 	uint16_t		port;				// def = 80;
 	std::string		index;				// def = server_root/index.html
 	std::string		error_page;			// def = server_root/error.html
-	uint64_t		head_length;		// def = 8k
 	uint64_t		body_length;		// def = 1M
 	bool			autoindex;			// def = off
 	uint32_t		timeout;			// def = 5s

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -193,7 +193,7 @@ void Client::makePostMsg()
 Client::Client(Socket &socket):
 	_port(socket.getPort()),
 	_content_length_left(EMPTY_CONTENT_LENGTH),
-	_chunked_len(CHUNKED_READY),
+	_chunked_length(CHUNKED_READY),
 	_sock_status(INITIALIZE),
 	_proc_status(PROC_INITIALIZE),
 	_file_path(),
@@ -312,6 +312,7 @@ int	Client::parseBody(std::string &tmp, size_t pos)
 			if (tmp[pos] == '\n')
 				tmp.erase(tmp[pos - 1] == '\r' ? pos - 1 : pos);
 			this->_content_length_left -= (pos + 1);
+			this->_body_length_left -= (pos + 1);
 		}
 		this->_request.getBody().push_back(tmp);
 		if (this->_content_length_left <= 0)
@@ -319,21 +320,24 @@ int	Client::parseBody(std::string &tmp, size_t pos)
 			return PARSE_BODY_END;
 		}
 	}
-	else if (this->_chunked_len == CHUNKED_READY)
+	else if (this->_chunked_length == CHUNKED_READY)
 	{
-		this->_chunked_len = static_cast<int>(ft_unsigned_hextol(tmp));
-		if (this->_chunked_len == 0)
+		this->_chunked_length = static_cast<int>(ft_unsigned_hextol(tmp));
+		if (this->_chunked_length == 0)
 			return PARSE_BODY_END;
 	}
 	else
 	{
-		if (static_cast<int>(tmp.length()) < this->_chunked_len)
-			tmp.erase(this->_chunked_len);
+		if (static_cast<int>(tmp.length()) < this->_chunked_length)
+			tmp.erase(this->_chunked_length);
 		this->_request.getBody().push_back(tmp);
-		this->_chunked_len -= tmp.length();
-		if (this->_chunked_len <= 0)
-			this->_chunked_len = CHUNKED_READY;
+		this->_chunked_length -= tmp.length();
+		this->_body_length_left -= tmp.length();
+		if (this->_chunked_length <= 0)
+			this->_chunked_length = CHUNKED_READY;
 	}
+	if (_body_length_left <= 0)
+		return PARSE_BODY_END;
 	return PARSE_BODY_LEFT;
 }
 
@@ -412,6 +416,7 @@ void Client::parseBuffer(char *buff, int len)
 	{
 		if ((pos = this->_buffer.find('\n')) == std::string::npos)
 			pos = this->_buffer.length();
+
 		if (this->_sock_status == RECV_BODY)
 		{
 			tmp = this->_buffer.substr(0, pos + 1);
@@ -508,6 +513,11 @@ void Client::makeErrorStatus(uint16_t status)
 	this->_file_path = config.error_page;
 }
 
+void Client::setBodyLength()
+{
+	this->_body_length_left = this->_config_location->body_length;
+}
+
 int Client::getFd()
 {
 	return this->_fd;
@@ -521,6 +531,11 @@ e_sock_status Client::getSockStatus()
 e_proc_status Client::getProcStatus()
 {
 	return this->_proc_status;
+}
+
+void		Client::setProcStatus(e_proc_status status)
+{
+	this->_proc_status = status;
 }
 
 const char *Client::SocketAcceptException::what() const throw()

--- a/srcs/Config.cpp
+++ b/srcs/Config.cpp
@@ -60,6 +60,8 @@ void Config::parseConfig(std::vector<std::string> &split, bool is_location)
 		if (is_location)
 			throw ConfigGroup::ConfigFormatException();
 		this->port = ft_atoi(split[1]);
+		if (this->port < 0 || this->port > 65535)
+			throw ConfigGroup::ConfigFormatException();
 	}
 	else if (!split[0].compare("index"))
 	{
@@ -72,6 +74,8 @@ void Config::parseConfig(std::vector<std::string> &split, bool is_location)
 	else if (!split[0].compare("body_length"))
 	{
 		this->body_length = ft_atoi(split[1]);
+		if (this->body_length <= 0)
+			throw ConfigGroup::ConfigFormatException();
 	}
 	else if (!split[0].compare("autoindex"))
 	{
@@ -85,6 +89,8 @@ void Config::parseConfig(std::vector<std::string> &split, bool is_location)
 	else if (!split[0].compare("timeout"))
 	{
 		this->timeout = ft_atoi(split[1]);
+		if (this->timeout <= 0)
+			throw ConfigGroup::ConfigFormatException();
 	}
 	else if (!split[0].compare("auth"))
 	{

--- a/srcs/Config.cpp
+++ b/srcs/Config.cpp
@@ -6,7 +6,6 @@
  */
 Config::Config():
 	port(80),
-	head_length(8000),
 	body_length(1000000),
 	autoindex(false),
 	timeout(5)
@@ -27,7 +26,6 @@ Config::Config(const Config &src, std::string &loc_path):
 	port(src.port),
 	index(src.index),
 	error_page(src.error_page),
-	head_length(src.head_length),
 	body_length(src.body_length),
 	autoindex(src.autoindex),
 	timeout(src.timeout),
@@ -71,13 +69,9 @@ void Config::parseConfig(std::vector<std::string> &split, bool is_location)
 	{
 		this->error_page = this->root + "/" + split[1];
 	}
-	else if (!split[0].compare("head_length"))
-	{
-		this->head_length = ft_atoi(split[1]);
-	}
 	else if (!split[0].compare("body_length"))
 	{
-		this->head_length = ft_atoi(split[1]);
+		this->body_length = ft_atoi(split[1]);
 	}
 	else if (!split[0].compare("autoindex"))
 	{

--- a/srcs/Webserver.cpp
+++ b/srcs/Webserver.cpp
@@ -129,7 +129,11 @@ void Webserver::readRequest(Client &client)
 void Webserver::handleResponse(Client &client)
 {
 	if (client.getProcStatus() == PROC_READY)
+	{
 		client.setClientResReady(_configs);
+		client.setBodyLength();
+		client.setProcStatus(CREATING);
+	}
 	if (client.getProcStatus() == CREATING)
 		client.makeMsg();
 	else if (client.getProcStatus() == SENDING)

--- a/test.conf
+++ b/test.conf
@@ -4,7 +4,6 @@ server
 	port 80
 	error_page error.html
 	index index.html
-	head_length 8000
 	body_length 1000000
 	autoindex off
 	timeout 10
@@ -34,7 +33,6 @@ server
 	port 800
 	error_page error.html
 	index index.html
-	head_length 8000
 	body_length 1000000
 	autoindex on
 	timeout 10
@@ -54,7 +52,6 @@ server
 	port 8000
 	error_page error.html
 	index index.html
-	head_length 8000
 	body_length 1000000
 	autoindex on
 	timeout 10


### PR DESCRIPTION
close #26 

- 서버 config 파일에 명시된 body_length로 body의 길이를 제한하였습니다.
- Client.cpp의 멤버 변수에 len, length라는 표현이 혼용되고 있어 변수명을 length로 통일하였습니다.
- head_length를 사용하지 않기로 하였으므로 해당 변수와 관련된 내용을 삭제하였습니다. 